### PR TITLE
Drive with object param

### DIFF
--- a/src/sbrick.js
+++ b/src/sbrick.js
@@ -601,11 +601,11 @@ let SBrick = (function() {
 
 		/**
 		* Helper function to find a port channel numbers
-		* @param {hexadecimal} port
+		* @param {number} portId - The index of the port in the this.ports array
 		* @returns {array} - hexadecimal numbers of both channels
 		*/
-		_getPortChannels( port ) {
-			return [ CHANNEL[port*2], CHANNEL[port*2+1] ];
+		_getPortChannels( portId ) {
+			return [ CHANNEL[portId*2], CHANNEL[portId*2+1] ];
 		}
 
 		/**

--- a/src/sbrick.js
+++ b/src/sbrick.js
@@ -57,19 +57,6 @@ let SBrick = (function() {
 	const CMD_PVM       = 0x2C; // Periodic Voltage Measurements
 
 	// SBrick Ports / Channels
-	const PORT    = [
-			0x00, // PORT0 (top-left)
-			0x01, // PORT1 (bottom-left)
-			0x02, // PORT2 (top-right)
-			0x03  // PORT3 (bottom-right)
-	];
-	const CHANNEL = [
-		0x00, 0x01, // PORT0 channels
-		0x02, 0x03, // PORT1 channels
-		0x04, 0x05, // PORT2 channels
-		0x06, 0x07  // PORT3 channels
-	];
-
 	const PORTS = [
 		{ hexId: 0x00, channelHexIds: [ 0x00, 0x01 ]},
 		{ hexId: 0x01, channelHexIds: [ 0x02, 0x03 ]},
@@ -105,10 +92,10 @@ let SBrick = (function() {
 
 			// export constants
 			this.NAME     = sbrick_name || "";
-			this.PORT0    = PORT[0];
-			this.PORT1    = PORT[1];
-			this.PORT2    = PORT[2];
-			this.PORT3    = PORT[3];
+			this.PORT0    = PORTS[0].hexId;
+			this.PORT1    = PORTS[1].hexId;
+			this.PORT2    = PORTS[2].hexId;
+			this.PORT3    = PORTS[3].hexId;
 			this.CW       = CLOCKWISE;
 			this.CCW      = COUNTERCLOCKWISE;
 			this.MAX      = MAX;
@@ -137,7 +124,7 @@ let SBrick = (function() {
 
 		/**
 		* Open the Web Bluetooth popup to search and connect the SBrick (filtered by name if previously specified)
-			* @returns {promise returning undefined}
+		* @returns {promise returning undefined}
 		*/
 		connect() {
 			this.SERVICES = {
@@ -324,7 +311,7 @@ let SBrick = (function() {
 		/**
 		* send quickDrive command
 		* @param {array} portObjs - An array with a setting objects {port, direction, power}
-										for every port you want to update
+									for every port you want to update
 		* @returns {undefined}
 		*/
 		quickDrive( portObjs ) {

--- a/src/sbrick.js
+++ b/src/sbrick.js
@@ -282,21 +282,27 @@ let SBrick = (function() {
 				// the old version with 3 params was used
 				portObj = {
 					portId: 	arguments[0],
-					direction: 	arguments[1],
+					direction: 	arguments[1] || CLOCKWISE,
 					power: 		arguments[2]
 				};
 				this._log('calling drive with 3 arguments is deprecated. use 1 object {portId, direction, power} instead.');
 			}
 
 			const portId = portObj.portId,
-				direction = portObj.direction,
+				direction = portObj.direction || CLOCKWISE,
 				power = portObj.power;
 
 			return new Promise( (resolve, reject) => {
-				if( portId !== null && direction !== null && power !== null ) {
+				if( portId !== undefined && direction !== undefined && power !== undefined ) {
 					resolve();
 				} else {
-					reject('Wrong input');
+					let msg = 'Wrong input: please specify ';
+					if (portId === undefined) { msg += 'portId'; }
+					if (power === undefined) {
+						if (portId === undefined) {	msg += ' and'; }
+						msg += ' power';
+					}
+					reject(msg);
 				}
 			} )
 			.then( ()=> {
@@ -338,7 +344,7 @@ let SBrick = (function() {
 				if( Array.isArray(portObjs) ) {
 					resolve();
 				} else {
-					reject('Wrong input');
+					reject('Wrong input: quickDrive expects array');
 				}
 			} )
 			.then( ()=> {

--- a/src/sbrick.js
+++ b/src/sbrick.js
@@ -416,7 +416,16 @@ let SBrick = (function() {
 						new Uint8Array( command )
 					);
 				});
-			} )
+			})
+			.then( () => {
+				// all went well, return an array with the channels and the settings we just applied
+				let returnData = [];
+
+				portIds.forEach((portId) => {
+					returnData.push(this._getPortData(portId));
+				});
+				return returnData;
+			})
 			.catch( e => { this._error(e) } );
 		}
 

--- a/src/sbrick.js
+++ b/src/sbrick.js
@@ -257,7 +257,7 @@ let SBrick = (function() {
 				}
 			} )
 			.then( ()=> {
-				return this._pvm( { port:portId, mode:OUTPUT } );
+				return this._pvm( { portId:portId, mode:OUTPUT } );
 			})
 			.then( () => {
 				let port = this.ports[portId];
@@ -353,7 +353,7 @@ let SBrick = (function() {
 				let array = [];
 				for(let i=0;i<array_ports.length;i++) {
 					array.push( {
-						port: array_ports[i],
+						portId: array_ports[i],
 						mode: OUTPUT
 					} );
 				}
@@ -421,7 +421,7 @@ let SBrick = (function() {
 					reject('wrong input');
 				}
 			} ).then( ()=> {
-				return this._pvm( { port:portId, mode:INPUT } );
+				return this._pvm( { portId:portId, mode:INPUT } );
 			}).then( ()=> {
 				let channels = this._getPortChannels(portId);
 				return this._adc(channels).then( data => {
@@ -544,10 +544,10 @@ let SBrick = (function() {
 				let update_pvm = false;
 				for(let i=0;i<4;i++) {
 					if( typeof array_ports[i] !== 'undefined' ) {
-						let port = array_ports[i].port;
+						let portId = array_ports[i].portId;
 						let mode = array_ports[i].mode;
-						if( this.ports[port].mode != mode ) {
-							this.ports[port].mode = mode;
+						if( this.ports[portId].mode != mode ) {
+							this.ports[portId].mode = mode;
 							update_pvm = true;
 						}
 					}

--- a/src/sbrick.js
+++ b/src/sbrick.js
@@ -336,7 +336,7 @@ let SBrick = (function() {
 						if (typeof portId === 'undefined') {
 							// the old version with port was used
 							portId = array_ports[i].port;
-							this._log('propery port is deprecated for quickDrive. Use portId instead.');
+							this._log('Propery "port" is deprecated for quickDrive. Use "portId" instead.');
 						}
 						array.push( { port: portId, mode: OUTPUT } );
 					}
@@ -430,7 +430,7 @@ let SBrick = (function() {
 		* @returns {promise}
 		*/
 		stopAll() {
-			return this.stop([ PORT[0], PORT[1], PORT[2], PORT[3] ]);
+			return this.stop([0, 1, 2, 3]);
 		}
 
 

--- a/src/sbrick.js
+++ b/src/sbrick.js
@@ -70,6 +70,13 @@ let SBrick = (function() {
 		0x06, 0x07  // PORT3 channels
 	];
 
+	const PORTS = [
+		{ hexId: 0x00, channelHexIds: [ 0x00, 0x01 ]},
+		{ hexId: 0x01, channelHexIds: [ 0x02, 0x03 ]},
+		{ hexId: 0x02, channelHexIds: [ 0x04, 0x05 ]},
+		{ hexId: 0x03, channelHexIds: [ 0x06, 0x07 ]}
+	];
+
 	// Port Mode
 	const INPUT  = 'input';
 	const OUTPUT = 'output';
@@ -211,11 +218,11 @@ let SBrick = (function() {
 		*/
 		disconnect() {
 			return new Promise( (resolve, reject) => {
-					if( this.isConnected() ) {
-						resolve();
-					} else {
-						reject('Not connected');
-					}
+				if( this.isConnected() ) {
+					resolve();
+				} else {
+					reject('Not connected');
+				}
 			} ).then( ()=> {
 				return this.stopAll().then( ()=>{
 					clearInterval( this.keepalive );
@@ -305,7 +312,7 @@ let SBrick = (function() {
 						port.busy = false;
 						return this.webbluetooth.writeCharacteristicValue(
 							UUID_CHARACTERISTIC_REMOTECONTROL,
-							new Uint8Array([ CMD_DRIVE, PORT[portId], port.direction, port.power ])
+							new Uint8Array([ CMD_DRIVE, PORTS[portId].hexId, port.direction, port.power ])
 						) }
 					);
 				}
@@ -569,7 +576,7 @@ let SBrick = (function() {
 		/**
 		* Enable "Power Voltage Measurements" (five times a second) on a specific PORT (on both CHANNELS)
 		* the values are stored in internal SBrick variables, to read them use _adc()
-		* @param {array} portObjs - an array of port status objects { port: PORT[0-3], mode: INPUT-OUTPUT}
+		* @param {array} portObjs - an array of port status objects { portId, mode: INPUT-OUTPUT}
 		* @returns {promise} - undefined
 		*/
 		_pvm( portObjs ) {
@@ -583,7 +590,7 @@ let SBrick = (function() {
 				if( !Array.isArray(portObjs) ) {
 					portObjs = [ portObjs ];
 				}
-				
+
 				let update_pvm = false;
 				portObjs.forEach( (portObj) => {
 					let portId = portObj.portId;
@@ -648,7 +655,7 @@ let SBrick = (function() {
 		* @returns {array} - hexadecimal numbers of both channels
 		*/
 		_getPortChannels( portId ) {
-			return [ CHANNEL[portId*2], CHANNEL[portId*2+1] ];
+			return PORTS[portId].channelHexIds;
 		}
 
 		/**

--- a/src/sbrick.js
+++ b/src/sbrick.js
@@ -271,12 +271,27 @@ let SBrick = (function() {
 
 		/**
 		* send drive command
-		* @param {number} portId - The index (0-3) of the port to update in the this.ports array
-		* @param {hexadecimal number} direction - The drive direction (0x00, 0x01 - you can use the constants SBrick.CLOCKWISE and SBrick.COUNTERCLOCKWISE)
-		* @param {number} power - The power level for the drive command 0-255
+		* @param {object} portObj - {portId, direction, power}
+		*		portId: {number} The index (0-3) of the port to update in the this.ports array
+		*		direction: {hexadecimal number} The drive direction (0x00, 0x01 - you can use the constants SBrick.CLOCKWISE and SBrick.COUNTERCLOCKWISE)
+		*		power {number} - The power level for the drive command 0-255
 		* @returns {promise returning object} - Returned object: portId, direction, power
 		*/
-		drive( portId, direction, power ) {
+		drive( portObj ) {
+			if (typeof portObj !== 'object') {
+				// the old version with 3 params was used
+				portObj = {
+					portId: 	arguments[0],
+					direction: 	arguments[1],
+					power: 		arguments[2]
+				};
+				this._log('calling drive with 3 arguments is deprecated. use 1 object {portId, direction, power} instead.');
+			}
+
+			const portId = portObj.portId,
+				direction = portObj.direction,
+				power = portObj.power;
+
 			return new Promise( (resolve, reject) => {
 				if( portId !== null && direction !== null && power !== null ) {
 					resolve();
@@ -332,6 +347,7 @@ let SBrick = (function() {
 					if (isNaN(portId)) {
 						// the old version with port instead of portId was used
 						portId = parseInt( portObj.port );
+						this._log('object property port is deprecated. use portId instead.');
 					}
 					let port = this.ports[portId];
 					port.power     = Math.min(Math.max(parseInt(Math.abs(portObj.power)), MIN), MAX);

--- a/src/sbrick.js
+++ b/src/sbrick.js
@@ -316,7 +316,7 @@ let SBrick = (function() {
 
 		/**
 		* send quickDrive command
-		* @param {array} array_ports - An array with a settings object {portId, direction, power}
+		* @param {array} array_ports - An array with a settings object {port, direction, power}
 										for every port you want to update
 		* @returns {undefined}
 		*/
@@ -329,32 +329,16 @@ let SBrick = (function() {
 				}
 			} )
 			.then( ()=> {
-				let array = [];
-				for(let i=0;i<4;i++) {
-					if( typeof array_ports[i] !== 'undefined' ) {
-						let portId = array_ports[i].portId;
-						if (typeof portId === 'undefined') {
-							// the old version with port was used
-							portId = array_ports[i].port;
-							this._log('Propery "port" is deprecated for quickDrive. Use "portId" instead.');
-						}
-						array.push( { port: portId, mode: OUTPUT } );
+				array_ports.forEach( (portObj) => {
+					let portId = parseInt( portObj.portId );
+					if (isNaN(portId)) {
+						// the old version with port instead of portId was used
+						portId = parseInt( portObj.port );
 					}
-				}
-			})
-			.then( ()=> {
-				for(let i=0;i<4;i++) {
-					if( typeof array_ports[i] !== 'undefined' ) {
-						let portId = parseInt( array_ports[i].portId );
-						if (isNaN(portId)) {
-							// the old version with port instead of portId was used
-							portId = parseInt( array_ports[i].port );
-						}
-						let port = this.ports[portId];
-						port.power     = Math.min(Math.max(parseInt(Math.abs(array_ports[i].power)), MIN), MAX);
-						port.direction = array_ports[i].direction ? COUNTERCLOCKWISE : CLOCKWISE;
-					}
-				}
+					let port = this.ports[portId];
+					port.power     = Math.min(Math.max(parseInt(Math.abs(portObj.power)), MIN), MAX);
+					port.direction = portObj.direction ? COUNTERCLOCKWISE : CLOCKWISE;
+				});
 				
 				if( !this.ports[0].busy && !this.ports[1].busy && !this.ports[2].busy && !this.ports[3].busy ) {
 					for(let i=0;i<4;i++) {
@@ -430,7 +414,7 @@ let SBrick = (function() {
 		* @returns {promise}
 		*/
 		stopAll() {
-			return this.stop([0, 1, 2, 3]);
+			return this.stop([0, 1, 2, 3])
 		}
 
 
@@ -441,7 +425,7 @@ let SBrick = (function() {
 		getBattery() {
 			return this._volt()
 			.then( volt => {
-					return parseInt( Math.abs( volt / MAX_VOLT * 100 ) );
+				return parseInt( Math.abs( volt / MAX_VOLT * 100 ) );
 			});
 		}
 

--- a/src/sbrick.js
+++ b/src/sbrick.js
@@ -340,25 +340,25 @@ let SBrick = (function() {
 					port.direction = portObj.direction ? COUNTERCLOCKWISE : CLOCKWISE;
 				});
 				
-				if( !this.ports[0].busy && !this.ports[1].busy && !this.ports[2].busy && !this.ports[3].busy ) {
-					for(let i=0;i<4;i++) {
-						this.ports[i].busy = true;
-					}
+				if(this._allPortsAreIdle()) {
+					this._setAllPortsBusy();
+
 					this.queue.add( () => {
 						let command = [];
-						for(let i=0;i<4;i++) {
-							this.ports[i].busy = false;
-							if( this.ports[i].mode===OUTPUT ) {
-								command.push( parseInt( parseInt(this.ports[i].power/MAX*MAX_QD).toString(2) + this.ports[i].direction, 2 ) );
+						this.ports.forEach( (port) => {
+							port.busy = false;
+							if( port.mode===OUTPUT ) {
+								command.push( parseInt( parseInt(port.power/MAX*MAX_QD).toString(2) + port.direction, 2 ) );
 							} else {
 								command.push( null );
 							}
-						}
+						});
+						
 						return this.webbluetooth.writeCharacteristicValue(
 							UUID_CHARACTERISTIC_QUICKDRIVE,
 							new Uint8Array( command )
-						) }
-					);
+						);
+					});
 				}
 			})
 			.catch( e => { this._error(e) } );
@@ -671,6 +671,34 @@ let SBrick = (function() {
 				console.log(msg);
 			}
 		}
+
+		/**
+		* check if no port is busy
+		* @returns {boolean}
+		*/
+		_allPortsAreIdle() {
+			let allAreIdle = true;
+			this.ports.forEach((port) => {
+				if (port.busy) {
+					allAreIdle = false;
+				}
+			});
+			
+			return allAreIdle;
+		}
+
+
+		/**
+		* set all ports to busy
+		* @returns {undefined}
+		*/
+		_setAllPortsBusy() {
+			this.ports.forEach((port) => {
+				port.busy = true;
+			});
+		};
+
+
 
 	}
 

--- a/src/sbrick.js
+++ b/src/sbrick.js
@@ -248,28 +248,28 @@ let SBrick = (function() {
 		}
 
 
-		drive( port, direction, power ) {
+		drive( portId, direction, power ) {
 			return new Promise( (resolve, reject) => {
-				if( PORT.indexOf(port)!=-1 && direction!=null && power!=null ) {
+				if( portId !== null && direction !== null && power !== null ) {
 					resolve();
 				} else {
 					reject('Wrong input');
 				}
 			} )
 			.then( ()=> {
-				return this._pvm( { port:port, mode:OUTPUT } );
+				return this._pvm( { port:portId, mode:OUTPUT } );
 			})
 			.then( () => {
-				this.ports[port].power     = Math.min(Math.max(parseInt(Math.abs(power)), MIN), MAX);
-				this.ports[port].direction = direction ? COUNTERCLOCKWISE : CLOCKWISE;
+				this.ports[portId].power     = Math.min(Math.max(parseInt(Math.abs(power)), MIN), MAX);
+				this.ports[portId].direction = direction ? COUNTERCLOCKWISE : CLOCKWISE;
 
-				if( !this.ports[port].busy ) {
-					this.ports[port].busy = true;
+				if( !this.ports[portId].busy ) {
+					this.ports[portId].busy = true;
 					this.queue.add( () => {
-						this.ports[port].busy = false;
+						this.ports[portId].busy = false;
 						return this.webbluetooth.writeCharacteristicValue(
 							UUID_CHARACTERISTIC_REMOTECONTROL,
-							new Uint8Array([ CMD_DRIVE, PORT[port], this.ports[port].direction, this.ports[port].power ])
+							new Uint8Array([ CMD_DRIVE, PORT[portId], this.ports[portId].direction, this.ports[portId].power ])
 						) }
 					);
 				}

--- a/src/sbrick.js
+++ b/src/sbrick.js
@@ -316,7 +316,7 @@ let SBrick = (function() {
 
 		/**
 		* send quickDrive command
-		* @param {array} array_ports - An array with a settings object {port, direction, power}
+		* @param {array} array_ports - An array with a settings object {portId, direction, power}
 										for every port you want to update
 		* @returns {undefined}
 		*/

--- a/src/sbrick.js
+++ b/src/sbrick.js
@@ -260,16 +260,18 @@ let SBrick = (function() {
 				return this._pvm( { port:portId, mode:OUTPUT } );
 			})
 			.then( () => {
-				this.ports[portId].power     = Math.min(Math.max(parseInt(Math.abs(power)), MIN), MAX);
-				this.ports[portId].direction = direction ? COUNTERCLOCKWISE : CLOCKWISE;
+				let port = this.ports[portId];
+				
+				port.power     = Math.min(Math.max(parseInt(Math.abs(power)), MIN), MAX);
+				port.direction = direction ? COUNTERCLOCKWISE : CLOCKWISE;
 
-				if( !this.ports[portId].busy ) {
-					this.ports[portId].busy = true;
+				if( !port.busy ) {
+					port.busy = true;
 					this.queue.add( () => {
-						this.ports[portId].busy = false;
+						port.busy = false;
 						return this.webbluetooth.writeCharacteristicValue(
 							UUID_CHARACTERISTIC_REMOTECONTROL,
-							new Uint8Array([ CMD_DRIVE, PORT[portId], this.ports[portId].direction, this.ports[portId].power ])
+							new Uint8Array([ CMD_DRIVE, PORT[portId], port.direction, port.power ])
 						) }
 					);
 				}

--- a/src/sbrick.js
+++ b/src/sbrick.js
@@ -407,7 +407,7 @@ let SBrick = (function() {
 				let command = [ CMD_BREAK ];
 				// update object values and build the command
 				portIds.forEach( (portId) => {
-					this.ports[portId.power] = 0;
+					this.ports[portId].power = 0;
 					command.push(portId);
 				});
 				this.queue.add( () => {


### PR DESCRIPTION
Right now, the drive method has to be called with 3 params (portId, direction, power), and the quickDrive method expects an array of port-setting objects [{portId, direction, power}, {portId, direction, power}, ...]
For consistency, I think it would be better to call the drive method with one such object instead of 3 separate arguments